### PR TITLE
Set Python Runtime to 3.6.6 in order to make Heroku happy.

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.7
+python-3.6.6


### PR DESCRIPTION
We are waiting on Heroku to pull heroku/heroku-buildpack-python#772 in order for Python 3.6.7 to work. For now, lets stay on 3.6.6.